### PR TITLE
image_parameters wrap to "global_config"

### DIFF
--- a/src/Configuration/Config.php
+++ b/src/Configuration/Config.php
@@ -15,8 +15,8 @@ class Config extends BaseConfig
     {
         $connectionString = $this->getValue(['parameters', 'hub', '#connectionString'], false);
         $imageParams = $this->getImageParameters();
-        if (isset($imageParams['hub']['#connectionString'])) {
-            $connectionString = $imageParams['hub']['#connectionString'];
+        if (isset($imageParams['global_config']['hub']['#connectionString'])) {
+            $connectionString = $imageParams['global_config']['hub']['#connectionString'];
         }
         if (!$connectionString) {
             throw new InvalidConfigurationException(

--- a/tests/functional/test-connection-connection-string-img-parameters/source/data/config.json
+++ b/tests/functional/test-connection-connection-string-img-parameters/source/data/config.json
@@ -6,8 +6,10 @@
     }
   },
   "image_parameters": {
-    "hub": {
-      "#connectionString": "%env(string:CONNECTION_STRING_NORMALIZED)%"
+    "global_config": {
+      "hub": {
+        "#connectionString": "%env(string:CONNECTION_STRING_NORMALIZED)%"
+      }
     }
   }
 }

--- a/tests/phpunit/ConfigTest.php
+++ b/tests/phpunit/ConfigTest.php
@@ -157,8 +157,10 @@ class ConfigTest extends AbstractTestCase
                     'tableId' => 'in.c-ex-generic-test.data',
                 ],
                 'image_parameters' => [
-                    'hub' => [
-                        '#connectionString' => $this->getHubNode()['#connectionString'],
+                    'global_config' => [
+                        'hub' => [
+                            '#connectionString' => $this->getHubNode()['#connectionString'],
+                        ],
                     ],
                 ],
             ],
@@ -179,8 +181,11 @@ class ConfigTest extends AbstractTestCase
                     'tableId' => 'in.c-ex-generic-test.data',
                 ],
                 'image_parameters' => [
-                    'hub' => [
-                        '#connectionString' => 'Endpoint=sb://abc.servicebus.windows.net;SharedAccessKeyName=fromImg',
+                    'global_config' => [
+                        'hub' => [
+                            '#connectionString' =>
+                                'Endpoint=sb://abc.servicebus.windows.net;SharedAccessKeyName=fromImg',
+                        ],
                     ],
                 ],
             ],


### PR DESCRIPTION
Ještě po domluvě s UI to zabalíme do "global_config" - https://keboola.slack.com/archives/CMTBFNLF8/p1614605310108900?thread_ts=1614598219.103500&cid=CMTBFNLF8