### PR TITLE
restore pecl event - tests failed weirdly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,8 +46,8 @@ RUN docker-php-ext-install sockets \
     && docker-php-ext-install pcntl
 
 # Install ext-event for react-php
-#RUN pecl install event \
-#    && docker-php-ext-enable event --ini-name zz-event.ini event
+RUN pecl install event \
+    && docker-php-ext-enable event --ini-name zz-event.ini event
 
 ENV LANGUAGE=en_US.UTF-8
 ENV LANG=en_US.UTF-8


### PR DESCRIPTION
When I merged the last PR the tests failed weirdly, so I will better restore the "pecl event" package